### PR TITLE
Bug de data no iPhone

### DIFF
--- a/pages/cadastrar/index.tsx
+++ b/pages/cadastrar/index.tsx
@@ -613,7 +613,7 @@ export default function MyApp({ Component, pageProps }) {
                   const date = new Date(`${year}-${month}-${day}`)
 
                   const schema = yup.object().shape({
-                    date: yup.date().required('Informe sua data de nascimento'),
+                    date: yup.date().required('Informe sua data de nascimento').nullable(),
                   })
 
                   schema

--- a/pages/cadastrar/index.tsx
+++ b/pages/cadastrar/index.tsx
@@ -610,7 +610,7 @@ export default function MyApp({ Component, pageProps }) {
                     return
                   }
 
-                  const date = new Date(`${year}-${month}-${day}`)
+                  const date = new Date(`${year}/${month}/${day}`)
 
                   const schema = yup.object().shape({
                     date: yup.date().required('Informe sua data de nascimento').typeError('Data inválida'),

--- a/pages/cadastrar/index.tsx
+++ b/pages/cadastrar/index.tsx
@@ -613,7 +613,7 @@ export default function MyApp({ Component, pageProps }) {
                   const date = new Date(`${year}-${month}-${day}`)
 
                   const schema = yup.object().shape({
-                    date: yup.date().required('Informe sua data de nascimento').nullable(),
+                    date: yup.date().required('Informe sua data de nascimento').nullable().typeError('Data inválida'),
                   })
 
                   schema

--- a/pages/cadastrar/index.tsx
+++ b/pages/cadastrar/index.tsx
@@ -613,7 +613,7 @@ export default function MyApp({ Component, pageProps }) {
                   const date = new Date(`${year}-${month}-${day}`)
 
                   const schema = yup.object().shape({
-                    date: yup.date().required('Informe sua data de nascimento').nullable().typeError('Data inválida'),
+                    date: yup.date().required('Informe sua data de nascimento').typeError('Data inválida'),
                   })
 
                   schema

--- a/pages/cadastrar/index.tsx
+++ b/pages/cadastrar/index.tsx
@@ -613,7 +613,7 @@ export default function MyApp({ Component, pageProps }) {
                   const date = new Date(`${year}-${month}-${day}`)
 
                   const schema = yup.object().shape({
-                    date: yup.date().required(),
+                    date: yup.date().required('Informe sua data de nascimento'),
                   })
 
                   schema

--- a/pages/perfil/index.tsx
+++ b/pages/perfil/index.tsx
@@ -786,7 +786,7 @@ export default function Index() {
                       button.disabled = true
                       button.classList.add('is-loading')
 
-                      const birthDate = new Date(`${date.year}-${date.month}-${date.day}`).toISOString()
+                      const birthDate = new Date(`${date.year}/${date.month}/${date.day}`).toISOString()
 
                       await fetch(`/api/users/${profile._id}`, {
                         method: 'PATCH',


### PR DESCRIPTION
- Não era possível cadastrar uma conta no iPhone, ocorria um erro na criação da data.
- Não era possível atualizar a data de nascimento no perfil no iPhone.
 
Testado no Chrome e Safari